### PR TITLE
Refactor : 입찰 및 즉시구매 검증, 예치금 생성일자 저장

### DIFF
--- a/src/main/java/com/fantion/backend/auction/controller/BidController.java
+++ b/src/main/java/com/fantion/backend/auction/controller/BidController.java
@@ -3,6 +3,9 @@ package com.fantion.backend.auction.controller;
 import com.fantion.backend.auction.dto.*;
 import com.fantion.backend.auction.service.BidService;
 import com.fantion.backend.common.dto.ResultDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -13,10 +16,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @RequestMapping("/bid")
 @RequiredArgsConstructor
+@Tag(name = "Bid", description = "Bid Service API")
 public class BidController {
 
     private final BidService bidService;
-
+    @Operation(summary = "입찰내역 구독", description = "입찰내역을 구독 할 때 사용하는 API")
+    @ApiResponse(responseCode = "200", description = "성공적으로 입찰내역을 구독했습니다.")
     @GetMapping(value = "/{auctionId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     private SseEmitter subscribeBid(@PathVariable("auctionId") Long auctionId){
         return bidService.subscribeBid(auctionId);

--- a/src/main/java/com/fantion/backend/auction/dto/BidAuctionCancelDto.java
+++ b/src/main/java/com/fantion/backend/auction/dto/BidAuctionCancelDto.java
@@ -1,5 +1,6 @@
 package com.fantion.backend.auction.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public class BidAuctionCancelDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Request{
+        @NotBlank(message = "경매 식별자는 필수 항목입니다.")
         private Long auctionId;             // 경매 식별자
 
     }

--- a/src/main/java/com/fantion/backend/auction/repository/AuctionRepository.java
+++ b/src/main/java/com/fantion/backend/auction/repository/AuctionRepository.java
@@ -27,7 +27,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
   List<Auction> findByAuctionTypeAndStatus(boolean auctionType,boolean status);
 
-  List<Auction> findByStatusAndReceiveChkAndCurrentBidder(boolean status,boolean receiveChk,String bidder);
+  List<Auction> findByStatusAndReceiveChkAndCurrentBidderAndCancelChk(boolean status,boolean receiveChk,String bidder,boolean cancelChk);
 
   List<Auction> findByStatusAndReceiveChkAndMember(boolean status, boolean receiveChk, Member member);
 

--- a/src/main/java/com/fantion/backend/auction/service/impl/BidServiceImpl.java
+++ b/src/main/java/com/fantion/backend/auction/service/impl/BidServiceImpl.java
@@ -440,7 +440,7 @@ public class BidServiceImpl implements BidService {
 
         // 이미 인계 확인이 되어있는 경우
         if (auction.isSendChk()) {
-            throw new CustomException(ALREADY_SEND_CHK);
+            throw new CustomException(ALREADY_CHKING);
         }
 
         // 인계 확인
@@ -470,7 +470,7 @@ public class BidServiceImpl implements BidService {
 
         // 이미 인수 확인이 되어있는 경우
         if (auction.isReceiveChk()) {
-            throw new CustomException(ALREADY_RECEIVE_CHK);
+            throw new CustomException(ALREADY_CHKING);
         }
 
         // 구매자 정보
@@ -533,9 +533,9 @@ public class BidServiceImpl implements BidService {
             throw new CustomException(ALREADY_CANCEL_CHK);
         }
 
-        // 이미 인수 확인이 되어있는 경우
-        if (cancelBidAuction.isReceiveChk()) {
-            throw new CustomException(ALREADY_RECEIVE_CHK);
+        // 이미 인계 또는 인수 확인이 되어있는 경우
+        if (cancelBidAuction.isReceiveChk() || cancelBidAuction.isSendChk()) {
+            throw new CustomException(ALREADY_CHKING);
         }
 
         // 로그인한 사용자 가져오기

--- a/src/main/java/com/fantion/backend/auction/service/impl/BidServiceImpl.java
+++ b/src/main/java/com/fantion/backend/auction/service/impl/BidServiceImpl.java
@@ -393,10 +393,10 @@ public class BidServiceImpl implements BidService {
         Member member = memberRepository.findByEmail(loginEmail)
                 .orElseThrow(()-> new CustomException(NOT_FOUND_MEMBER));
 
-        // 경매가 마감되어있으면서 인수 확인이 되어있지 않는 경매 물품 조회
+        // 경매가 마감되어있으면서 인수 확인이 되어있지 않고 취소된 경매가 아닌 물품 조회
         // 구매중인 경매물품 조회
-        List<Auction> buyList = auctionRepository
-                .findByStatusAndReceiveChkAndCurrentBidder(false, false,member.getNickname());
+        List<Auction> buyList = auctionRepository.findByStatusAndReceiveChkAndCurrentBidderAndCancelChk(
+                false, false,member.getNickname(),false);
 
         // 판매중인 경매물품 조회
         List<Auction> sellList = auctionRepository

--- a/src/main/java/com/fantion/backend/exception/ErrorCode.java
+++ b/src/main/java/com/fantion/backend/exception/ErrorCode.java
@@ -41,6 +41,8 @@ public enum ErrorCode {
     NOT_FOUND_BID("존재하지 않는 입찰입니다.",HttpStatus.BAD_REQUEST),
     NOT_PRIVATE_BID_CANCEL("비공개 입찰만 입찰 취소가 가능합니다.",HttpStatus.BAD_REQUEST),
     NOT_ENOUGH_BALANCE("예치금이 부족합니다.",HttpStatus.BAD_REQUEST),
+    INVALID_BID_PRICE("잘못된 입찰가입니다.",HttpStatus.BAD_REQUEST),
+    INVALID_BID("잘못된 입찰입니다",HttpStatus.BAD_REQUEST),
     NOT_SEND_CHKING("인계 확인이 되어있지 않습니다.",HttpStatus.BAD_REQUEST),
     ALREADY_SEND_CHK("이미 인계확인이 되어있습니다.",HttpStatus.BAD_REQUEST),
     ALREADY_RECEIVE_CHK("이미 인수확인이 되어있습니다.",HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/fantion/backend/exception/ErrorCode.java
+++ b/src/main/java/com/fantion/backend/exception/ErrorCode.java
@@ -44,8 +44,7 @@ public enum ErrorCode {
     INVALID_BID_PRICE("잘못된 입찰가입니다.",HttpStatus.BAD_REQUEST),
     INVALID_BID("잘못된 입찰입니다",HttpStatus.BAD_REQUEST),
     NOT_SEND_CHKING("인계 확인이 되어있지 않습니다.",HttpStatus.BAD_REQUEST),
-    ALREADY_SEND_CHK("이미 인계확인이 되어있습니다.",HttpStatus.BAD_REQUEST),
-    ALREADY_RECEIVE_CHK("이미 인수확인이 되어있습니다.",HttpStatus.BAD_REQUEST),
+    ALREADY_CHKING("이미 인계 또는 인수 확인이 되어있습니다.",HttpStatus.BAD_REQUEST),
     ALREADY_CANCEL_CHK("이미 거래취소가 되어있습니다.",HttpStatus.BAD_REQUEST),
     NOT_CONFIRMED_RECEIVE("인수확인이 아직 완료되지 않았습니다.", HttpStatus.BAD_REQUEST),
 


### PR DESCRIPTION
## 🛠️ PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

<br/>

## 💾 반영 브랜치
ex) feat/create-bid -> dev

<br/>

## 👨‍🔧 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
- **AS-IS**
0원 이하이거나 즉시 구매가 이상인 경우에도 입찰이 가능했었음
경매 종료를 그날 자정 낙찰 시에 처리하게 되어서 경매 종료일이 지나도 입찰이 가능할 수 있었음
본인이 판매자인 경우에도 본인 물품에 입찰이 가능함
예치금 내역 생성시 생성일자가 null이였음
- **TO-BE**
0원 이하이거나 즉시 구매가 이상인 경우에 입찰 불가능하도록 수정
종료일이 지난경우에도 입찰 불가능하도록 조건 추가
본인이 판매자인 경우에 입찰 불가능하도록 수정
생성일자를 넣어주도록 수정
  <br />

## 🎨 이미지 첨부
<!-- 이미지 첨부는 자유 입니다. 하실분은 하시고 안하실 분은 안하셔도 됩니다. -->
<img src="파일주소" width="50%" height="50%"/>
<br/>

## 👨‍💻 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
